### PR TITLE
feat&docs: Add Loon Support and tutorial docs

### DIFF
--- a/docs/proxies/loon.md
+++ b/docs/proxies/loon.md
@@ -1,0 +1,19 @@
+---
+outline: deep
+---
+
+# Loon 配置
+
+::: tip
+Loon 需要外区账号，且购买后才能安装；[<i-fa6-solid-magnifying-glass-location style="display: inline-block; vertical-align: middle;" />](https://apps.apple.com/us/app/loon/id1373567447)<br>
+如果你对如何获取 Loon 感到疑惑，推荐 iOS 用户使用 Sing-box 方案。
+:::
+
+1. 安装 Loon：
+    - 请自行寻找安装方法
+    - 请尽量不要在 UsagiPass 用户群寻求安装帮助，如对安装有困难推荐查看 Sing-box 方案
+2. 添加 UsagiPass 节点
+    - 在 Loon 的 配置 - 所有节点 中，点击右上角加号，添加一个订阅：https://raw.githubusercontent.com/ShiFangming0823/ShiFangming0823/refs/heads/main/UsagiPass.txt
+3. 添加 UsagiPass 插件
+    - 在 Loon 的 配置 - 插件 中，添加一个插件：https://raw.githubusercontent.com/ShiFangming0823/UsagiPass/refs/heads/main/public/UsagiPass.plugin
+4. **回到 仪表 页面，点击右上角开关，Loon成功启动后即可生效！**

--- a/docs/proxies/loon.md
+++ b/docs/proxies/loon.md
@@ -13,7 +13,7 @@ Loon 需要外区账号，且购买后才能安装；[<i-fa6-solid-magnifying-gl
     - 请自行寻找安装方法
     - 请尽量不要在 UsagiPass 用户群寻求安装帮助，如对安装有困难推荐查看 Sing-box 方案
 2. 添加 UsagiPass 节点
-    - 在 Loon 的 配置 - 所有节点 中，点击右上角加号，添加一个订阅：https://raw.githubusercontent.com/ShiFangming0823/ShiFangming0823/refs/heads/main/UsagiPass.txt
+    - 在 Loon 的 配置 - 所有节点 中，点击右上角加号，添加一个订阅：https://raw.githubusercontent.com/ShiFangming0823/UsagiPass/refs/heads/develop/public/UsagiPass.txt
 3. 添加 UsagiPass 插件
-    - 在 Loon 的 配置 - 插件 中，添加一个插件：https://raw.githubusercontent.com/ShiFangming0823/UsagiPass/refs/heads/main/public/UsagiPass.plugin
+    - 在 Loon 的 配置 - 插件 中，添加一个插件：https://raw.githubusercontent.com/ShiFangming0823/UsagiPass/refs/heads/develop/public/UsagiPass.plugin
 4. **回到 仪表 页面，点击右上角开关，Loon成功启动后即可生效！**

--- a/public/UsagiPass.plugin
+++ b/public/UsagiPass.plugin
@@ -1,0 +1,10 @@
+#!name=UsagiPass
+#!desc=通过代理替换 wq.wahlap.net 网页，将请求重定向到 up.turou.fun。
+#!author=iAPara
+#!icon=
+
+[rule]
+DOMAIN-SUFFIX, wq.wahlap.net, UsagiPass
+DOMAIN-SUFFIX, sys-all.cn, UsagiPass
+DOMAIN-SUFFIX, sys-allnet.cn, UsagiPass
+DOMAIN, tgk-wcaime.wahlap.com, UsagiPass

--- a/public/UsagiPass.txt
+++ b/public/UsagiPass.txt
@@ -1,0 +1,1 @@
+ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpvNWJaVUhIdmJGTHkzZVhremkyTQ==@up.turou.fun:15678#UsagiPass


### PR DESCRIPTION
feat&docs: Add Loon Support and according instruction docs.

- public/UsagiPass.txt is the subscription link of the UsagiPass server.
- public/UsagiPass.plugin is the plugin file of Loon, including the rules of redirection.
- docs/proxies/loon.md is the tutorial docs, providing step-by-step instructions on how to config Loon to enable UsagiPass. 